### PR TITLE
fix(adapter): use AdsGlobalPackage as the product in SPM dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
       name: "PangleAdapterTarget",
       dependencies: [
         .target(name: "PangleAdapter"),
-        .product(name: "PangleSDK", package: "AdsGlobalPackage")
+        .product(name: "AdsGlobalPackage", package: "AdsGlobalPackage")
       ],
       path: "PangleAdapterTarget"
     ),


### PR DESCRIPTION
- Replace `.product(name: "PangleSDK", package: "AdsGlobalPackage")` with `.product(name: "AdsGlobalPackage", package: "AdsGlobalPackage")`
- This fixes a resolution error caused by product/package mismatch.


This PR fixes the SPM product mismatch.

Closes #1